### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # app-dev
  My first repository
+**young sheldon**
+*Young Sheldon is an American coming-of-age sitcom television series created by Chuck Lorre and Steven Molaro that aired on CBS from September 25, 2017, to May 16, 2024.*
+**cast**
+-iain armitage
+-raegan revord
+-zoe perry


### PR DESCRIPTION
Young Sheldon is a prequel sitcom series to The Big Bang Theory, following the childhood of Sheldon Cooper in East Texas. Learn about the plot, cast, episodes, timeline, production and trivia of the show that ran from 2017 to 2024.